### PR TITLE
Update Pathfinder.cfg

### DIFF
--- a/For Release/GameData/KerbetrotterLtd/FelineUtilityRover/Patches/Pathfinder.cfg
+++ b/For Release/GameData/KerbetrotterLtd/FelineUtilityRover/Patches/Pathfinder.cfg
@@ -29,7 +29,7 @@
 	}
 }
 
-PARTUPGRADE
+PARTUPGRADE:FOR[FelineUtilityRover]:NEEDS[Pathfinder]
 {
 	name = MobileLabScienceUpgrade
 	partIcon = WBI.CrewCab


### PR DESCRIPTION
Missing :FOR[FelineUtilityRover]:NEEDS[Pathfinder] in PARTUPGRADE definition