### PR TITLE
Add missing comma in FelineUtilityRover.version

### DIFF
--- a/For Release/GameData/KerbetrotterLtd/FelineUtilityRover/FelineUtilityRover.version
+++ b/For Release/GameData/KerbetrotterLtd/FelineUtilityRover/FelineUtilityRover.version
@@ -2,7 +2,7 @@
     "NAME":"Feline Utility Rover",
     "URL":"https://raw.githubusercontent.com/Nils277/FelineUtilityRovers/master/For%20Release/GameData/KerbetrotterLtd/FelineUtilityRover/FelineUtilityRover.version",
     "DOWNLOAD":"https://github.com/Nils277/FelineUtilityRovers/releases",
-    
+
     "GITHUB":{
         "USERNAME":"Nils277",
         "REPOSITORY":"FelineUtilityRovers",
@@ -20,13 +20,13 @@
         "MINOR": 9,
         "PATCH": 1
     },
-    
+
     "KSP_VERSION_MAX":
     {
         "MAJOR": 1,
         "MINOR": 9,
         "PATCH": 9
-    }
+    },
   
     "KSP_VERSION_MIN":
     {


### PR DESCRIPTION
## Background
CKAN's NetKAN bot recently got an upgrade to do more soft-checks on mods (i.e. trigger warnings, but don't fail inflation), to help us find places where we can improve mods' metadata.
(Some of the soft-checks have been hard-checks accidentally, but that's a different story)

As a result, it also found the version file included in FUR, even though we aren't using it to generate the compatibility data currently (there is no `$vref` pointing to it in the netkan file). It detected the following error:
> New inflation error for FelineUtilityRovers: Error parsing version file GameData/KerbetrotterLtd/FelineUtilityRover/FelineUtilityRover.version: After parsing a value an unexpected character was encountered: ". Path 'KSP_VERSION_MAX', line 31, position 4.

## Changes
This PR adds the missing comma to the version file, right after the `KSP_VERSION_MAX` block.

When the version file is fixed, we can also update the netkan file to use the version file to generate compatibility data, so that it is not limited to the version entered in SpaceDock anymore.

---

I'm also using this occasion to shamelessly self-promote this tool I wrote, which validates version files to catch errors like this when creating pull-requests or pushing to a branch:
https://github.com/DasSkelett/AVC-VersionFileValidator

In this case, it would have outputted the following error:
```
Failed loading temp/FelineUtilityRover.version as JSON. 
Check for syntax errors around the mentioned line: 
Expecting ',' delimiter: line 31 column 5 (char 682)
```

If you decide to give it a go, I can do a PR to add the workflow file to the repository.